### PR TITLE
Expose postUrl and rename annotator object

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -74,6 +74,7 @@
     </div>
     <script>
         var dataUrl = '/static/json/sample_data.json';
+        var postUrl = '/<post_url>'; // This is where data posts to
 
         $(document).ready(function(){
             $('.modal-trigger').leanModal();

--- a/static/js/src/main.js
+++ b/static/js/src/main.js
@@ -13,7 +13,7 @@
  *       magma // color scheme array that maps 0 - 255 to rgb values
  *    
  */
-function UrbanEars() {
+function Annotator() {
     this.wavesurfer;
     this.playBar;
     this.stages;
@@ -73,7 +73,7 @@ function UrbanEars() {
     this.addEvents();
 }
 
-UrbanEars.prototype = {
+Annotator.prototype = {
     addWaveSurferEvents: function() {
         var my = this;
 
@@ -242,8 +242,8 @@ UrbanEars.prototype = {
 
 function main() {
     // Create all the components
-    var urbanEars = new UrbanEars();
+    var annotator = new Annotator();
     // Load the first audio annotation task
-    urbanEars.loadNextTask();
+    annotator.loadNextTask();
 }
 main();

--- a/static/js/src/main.js
+++ b/static/js/src/main.js
@@ -215,15 +215,12 @@ UrbanEars.prototype = {
 
     // Make POST request, passing back the content data. On success load in the next task
     post: function (content) {
-        console.log("This post will fail since this is a frontend demo.");
-        console.log("Here is the data about the annotation task");
-        console.log(content);
         var my = this;
         $.ajax({
             type: 'POST',
-            url: '/<post_url>',
+            url: $.getJSON(postUrl),
             contentType: 'application/json',
-            data: content
+            data: JSON.stringify(content)
         })
         .done(function(data) {
             // If the last task had a hiddenImage component, remove it


### PR DESCRIPTION
This PR implements three small changes that we identified as useful for the openmic project:

1. Expose the `postUrl` variable at the document level, similar to the `dataUrl` variable.  This way, application code does not need to modify `js/src/main.js` to specify the end-point
2. Renamed the `UrbanEars` object to have a more generic name `Annotator`.
3. Automatically JSON-encode post contents.