### PR TITLE
Track-style annotations

### DIFF
--- a/curio_original/audio.html
+++ b/curio_original/audio.html
@@ -25,7 +25,13 @@
 <!-- Modal Structure -->
 <div id="video-modal" class="modal">
     <div class="modal-content">
-        <h4>Tutorial Video</h4>
+        <h4>Instructions</h4>
+        <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9312;</span> &nbsp; Familiarize yourself with the list of sound labels under the audio recording.</h6>
+        <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9313;</span> &nbsp; Click the play button and listen to the recording.</h6>
+        <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9314;</span> &nbsp; For each sound event that you hear click and drag on the visualization to create a new annotation.</h6>
+        <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9315;</span> &nbsp; When creating a new annotation be as precise as possible. </h6>
+        <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9316;</span> &nbsp; Select the appropriate label and indicate whether the sound is near or far.</h6>
+        <br>
         <div class="videowrapper">
             <iframe id="tutorial-video" width="100%" height="100%" frameborder="0" allowfullscreen></iframe>
         </div>
@@ -38,15 +44,9 @@
     <div class="col s3">&nbsp; </div>
     <div class="col s6">
         <h4 class="center">Highlight &amp; Label Each Sound</h4>
-        <div class="instructions">
-            <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9312;</span> &nbsp; Familiarize yourself with the list of sound labels under the audio recording.</h6>
-            <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9313;</span> &nbsp; Click the play button and listen to the recording.</h6>
-            <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9314;</span> &nbsp; For each sound event that you hear click and drag on the visualization to create a new annotation. Be as precise as possible. </h6>
-            <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9315;</span> &nbsp; Select the appropriate label and indicate whether the sound is near or far.</h6>
-        </div>
     </div>
     <div class="col s3 right">
-        <a class="waves-effect waves-light modal-trigger right btn" href="#video-modal">Tutorial Video</a>
+        <a class="waves-effect waves-light modal-trigger right btn" href="#video-modal">Instructions</a>
     </div>
 </div>
 <div class="annotation">

--- a/curio_original/audio.html
+++ b/curio_original/audio.html
@@ -25,7 +25,7 @@
 <!-- Modal Structure -->
 <div id="video-modal" class="modal">
     <div class="modal-content">
-        <h4>Instructions</h4>
+        <h4>Highlight &amp; Label Each Sound</h4>
         <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9312;</span> &nbsp; Familiarize yourself with the list of sound labels under the audio recording.</h6>
         <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9313;</span> &nbsp; Click the play button and listen to the recording.</h6>
         <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9314;</span> &nbsp; For each sound event that you hear click and drag on the visualization to create a new annotation.</h6>
@@ -43,7 +43,6 @@
 <div class="row">
     <div class="col s3">&nbsp; </div>
     <div class="col s6">
-        <h4 class="center">Highlight &amp; Label Each Sound</h4>
     </div>
     <div class="col s3 right">
         <a class="waves-effect waves-light modal-trigger right btn" href="#video-modal">Instructions</a>

--- a/curio_original/main.js
+++ b/curio_original/main.js
@@ -37,7 +37,7 @@ function UrbanEars() {
     });
 
     // Create wavesurfer (audio visualization component)
-    var height = 128;
+    var height = 256;
     this.wavesurfer = Object.create(WaveSurfer);
     this.wavesurfer.init({
         container: '.audio_visual',

--- a/examples/index.html
+++ b/examples/index.html
@@ -78,6 +78,7 @@
 
         $(document).ready(function(){
             $('.modal-trigger').leanModal();
+            $('#video-modal').openModal();
         });
     </script>
 </body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -36,7 +36,7 @@
         <div class="col s6 ">
             <div class="right">
                 <h5>Sound Labeling Task</h5>
-                <a class="waves-effect waves-light modal-trigger right btn" href="#video-modal">Instructions</a>
+                <a class="waves-effect waves-light modal-trigger right btn" id="trigger" href="#video-modal">Instructions</a>
             </div>
         </div>
         <div class="col s12">
@@ -44,16 +44,14 @@
         </div>
     </div>
     <!-- Modal Structure -->
-        <div id="video-modal" class="modal">
+        <div id="video-modal" class="modal" style="max-height: 100% !important;">
             <div class="modal-content">
                 <h4>Instructions</h4>
-                <div class="instructions">
                     <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9312;</span> &nbsp; Familiarize yourself with the list of sound labels under the audio recording.</h6>
                     <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9313;</span> &nbsp; Click the play button and listen to the recording.</h6>
                     <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9314;</span> &nbsp; For each sound event that you hear click and drag on the visualization to create a new annotation.</h6>
                     <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9315;</span> &nbsp; When creating a new annotation be as precise as possible. </h6>
                     <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9316;</span> &nbsp; Select the appropriate label and indicate whether the sound is near or far.</h6>
-                </div>
                 <br>
                 <div class="videowrapper">
                     <iframe id="tutorial-video" width="100%" height="100%" frameborder="0" allowfullscreen></iframe>

--- a/examples/index.html
+++ b/examples/index.html
@@ -28,30 +28,22 @@
             <div class="divider"></div>
         </div>
         <div class="col s6">
-            <div class="left">
-                <h5>Recording <span id="recording-index"></span> of 9</h5>
-                <h6 class="left time">approx. <span id="time-remaining"></span> minutes remaining</h6>
-            </div>
         </div>
         <div class="col s6 ">
-            <div class="right">
-                <h5>Sound Labeling Task</h5>
+            <div class="right" style="padding-top: 10px;">
                 <a class="waves-effect waves-light modal-trigger right btn" id="trigger" href="#video-modal">Instructions</a>
             </div>
-        </div>
-        <div class="col s12">
-            <div class="divider bottom"></div>
         </div>
     </div>
     <!-- Modal Structure -->
         <div id="video-modal" class="modal" style="max-height: 100% !important;">
             <div class="modal-content">
-                <h4>Instructions</h4>
-                    <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9312;</span> &nbsp; Familiarize yourself with the list of sound labels under the audio recording.</h6>
-                    <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9313;</span> &nbsp; Click the play button and listen to the recording.</h6>
-                    <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9314;</span> &nbsp; For each sound event that you hear click and drag on the visualization to create a new annotation.</h6>
-                    <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9315;</span> &nbsp; When creating a new annotation be as precise as possible. </h6>
-                    <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9316;</span> &nbsp; Select the appropriate label and indicate whether the sound is near or far.</h6>
+                <h4>Highlight & Label Each Sound</h4>
+                <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9312;</span> &nbsp; Familiarize yourself with the list of sound labels under the audio recording.</h6>
+                <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9313;</span> &nbsp; Click the play button and listen to the recording.</h6>
+                <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9314;</span> &nbsp; For each sound event that you hear click and drag on the visualization to create a new annotation.</h6>
+                <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9315;</span> &nbsp; When creating a new annotation be as precise as possible. </h6>
+                <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9316;</span> &nbsp; Select the appropriate label and indicate whether the sound is near or far.</h6>
                 <br>
                 <div class="videowrapper">
                     <iframe id="tutorial-video" width="100%" height="100%" frameborder="0" allowfullscreen></iframe>
@@ -61,9 +53,6 @@
                 <a href="#!" class=" modal-action modal-close waves-effect waves-red btn-flat">Close</a>
             </div>
         </div>
-    <div class="row prompt">
-        <h4 class="center">Highlight &amp; Label Each Sound</h4>
-    </div>
     <div class="annotation">
         <div class="labels"></div>
         <div class="audio_visual"></div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -36,7 +36,7 @@
         <div class="col s6 ">
             <div class="right">
                 <h5>Sound Labeling Task</h5>
-                <a class="waves-effect waves-light modal-trigger right btn" href="#video-modal">Tutorial Video</a>
+                <a class="waves-effect waves-light modal-trigger right btn" href="#video-modal">Instructions</a>
             </div>
         </div>
         <div class="col s12">
@@ -46,7 +46,15 @@
     <!-- Modal Structure -->
         <div id="video-modal" class="modal">
             <div class="modal-content">
-                <h4>Tutorial Video</h4>
+                <h4>Instructions</h4>
+                <div class="instructions">
+                    <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9312;</span> &nbsp; Familiarize yourself with the list of sound labels under the audio recording.</h6>
+                    <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9313;</span> &nbsp; Click the play button and listen to the recording.</h6>
+                    <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9314;</span> &nbsp; For each sound event that you hear click and drag on the visualization to create a new annotation.</h6>
+                    <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9315;</span> &nbsp; When creating a new annotation be as precise as possible. </h6>
+                    <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9316;</span> &nbsp; Select the appropriate label and indicate whether the sound is near or far.</h6>
+                </div>
+                <br>
                 <div class="videowrapper">
                     <iframe id="tutorial-video" width="100%" height="100%" frameborder="0" allowfullscreen></iframe>
                 </div>
@@ -57,12 +65,6 @@
         </div>
     <div class="row prompt">
         <h4 class="center">Highlight &amp; Label Each Sound</h4>
-        <div class="instructions">
-            <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9312;</span> &nbsp; Familiarize yourself with the list of sound labels under the audio recording.</h6>
-            <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9313;</span> &nbsp; Click the play button and listen to the recording.</h6>
-            <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9314;</span> &nbsp; For each sound event that you hear click and drag on the visualization to create a new annotation. Be as precise as possible. </h6>
-            <h6 class="instruction"><span style="color: #00B1B9; font-size: 18px; font-weight: 600;">&#9315;</span> &nbsp; Select the appropriate label and indicate whether the sound is near or far.</h6>
-        </div>
     </div>
     <div class="annotation">
         <div class="labels"></div>

--- a/static/css/urban-ears.css
+++ b/static/css/urban-ears.css
@@ -283,8 +283,6 @@ input.form-control.duration {
 
 .instructions {
   padding-top: 20px;
-  margin: 0 auto;
-  width: 650px;
 }
 
 .time {

--- a/static/css/urban-ears.css
+++ b/static/css/urban-ears.css
@@ -192,7 +192,7 @@
 
 .current_region {
   z-index: 5000 !important;
-  border: 2px solid rgba(0, 177, 185, 0.40);
+  border: 2px solid rgba(0, 177, 185, 0.85);
 }
 
 tag.current_label {

--- a/static/css/urban-ears.css
+++ b/static/css/urban-ears.css
@@ -15,7 +15,7 @@
 }
 
 .audio_visual wave {
-  height: 148px !important;
+  height: 276px !important;
 }
 
 .audio_visual > wave {
@@ -55,7 +55,7 @@
 
 .creation_stage_container {
   text-align: center;
-  min-height: 175px;
+  min-height: 303px;
   position: relative;
 }
 

--- a/static/js/src/annotation_stages.js
+++ b/static/js/src/annotation_stages.js
@@ -725,6 +725,8 @@ AnnotationStages.prototype = {
     // Event Handler: triggered when region is first started to be created, adds action to event list
     trackBeginingOfRegionCreation: function(region) {
         this.trackEvent('start-to-create', region.id);
+        $(region.element).addClass('current_region');
+        $(region.annotationLabel.element).addClass('current_label');
     },
 
     // Event Handler: triggered when region is first started to be created

--- a/static/js/src/annotation_stages.js
+++ b/static/js/src/annotation_stages.js
@@ -87,7 +87,7 @@ StageTwoView.prototype = {
 function StageThreeView() {
     this.dom = null;
     this.editOptionsDom = null;
-    this.colors = ['rgba(236,0,251,0.4)', 'rgba(39,117,243,0.4)', 'rgba(33,177,4,0.4)'];
+    this.colors = ['#870f4f', '#000080', '#6a1b9a'];
 }
 
 StageThreeView.prototype = {

--- a/static/js/src/annotation_stages.js
+++ b/static/js/src/annotation_stages.js
@@ -87,7 +87,11 @@ StageTwoView.prototype = {
 function StageThreeView() {
     this.dom = null;
     this.editOptionsDom = null;
+    // Note that this assumes there are never more than 3 proximity labels
     this.colors = ['#870f4f', '#000080', '#6a1b9a'];
+    this.colors.forEach(function (color, index) {
+        $('<style>.proximity1_tag:hover,.proximity' + index + '_tag.selected{background-color: ' + color + '}</style>').appendTo('head');
+    });
 }
 
 StageThreeView.prototype = {
@@ -142,7 +146,7 @@ StageThreeView.prototype = {
 
         proximityTags.forEach(function (tagName, index) {
             var tag = $('<button>', {
-                class: 'proximity_tag btn',
+                class: 'proximity_tag btn proximity' + index + '_tag',
                 text: tagName,
             });
             // When a proximity tag is clicked fire the 'change-tag' event with what proximity it is and

--- a/static/js/src/main.js
+++ b/static/js/src/main.js
@@ -33,7 +33,7 @@ function Annotator() {
     });
 
     // Create wavesurfer (audio visualization component)
-    var height = 128;
+    var height = 256;
     this.wavesurfer = Object.create(WaveSurfer);
     this.wavesurfer.init({
         container: '.audio_visual',

--- a/static/js/src/wavesurfer.labels.js
+++ b/static/js/src/wavesurfer.labels.js
@@ -216,11 +216,11 @@ WaveSurfer.Label = {
     // The bottom parameter is how many pixels away from the label container's bottom the label element will be placed
     updateRender: function(bottom) {
         this.text.innerHTML = (this.region.annotation || '?');
-        var offset = (this.region.element.offsetWidth - this.element.offsetWidth) / 2
         this.style(this.element, {
-            left: Math.max(this.region.element.offsetLeft + offset, 0) + 'px',
+            left: this.region.element.offsetLeft + 'px',
             bottom: bottom + 'px',
-            zIndex: this.wavesurfer.drawer.wrapper.scrollWidth - this.element.offsetWidth
+            width: this.region.element.offsetWidth + 'px',
+            zIndex: this.wavesurfer.drawer.wrapper.scrollWidth - this.element.offsetWidth,
         });
     },
 

--- a/static/js/src/wavesurfer.labels.js
+++ b/static/js/src/wavesurfer.labels.js
@@ -247,6 +247,7 @@ WaveSurfer.Label = {
             left: this.region.element.offsetLeft + 'px',
             bottom: bottom + 'px',
             width: this.region.element.offsetWidth + 'px',
+            backgroundColor: this.region.color,
             zIndex: this.wavesurfer.drawer.wrapper.scrollWidth - this.element.offsetWidth,
         });
     },

--- a/static/js/src/wavesurfer.labels.js
+++ b/static/js/src/wavesurfer.labels.js
@@ -29,9 +29,11 @@ WaveSurfer.Labels = {
 
         this.width = drawer.width;
         this.pixelRatio = this.drawer.params.pixelRatio;
-        this.height = this.params.height || 40;
         this.labelsElement = null;
         this.labels = {};
+        this.rowHeight = this.params.rowHeight || 20;
+        this.maxRows = this.params.maxRows || 6;
+        this.height = this.params.height || (this.rowHeight * this.maxRows);
 
         // Create & append wrapper element to container
         this.createWrapper();
@@ -51,6 +53,8 @@ WaveSurfer.Labels = {
         wavesurfer.on('region-created', this.add.bind(this));
         // Update a label when its region is updated
         wavesurfer.on('region-updated', this.rearrange.bind(this));
+        // Rearrange labels when a region is deleted
+        wavesurfer.on('region-removed', this.rearrange.bind(this));
     },
 
     // Remove the wrapper element
@@ -129,32 +133,42 @@ WaveSurfer.Labels = {
         // First place all label elements in bottom row
         for (var id in this.labels) {
             // 2 px above wavesurfer canvas
-            this.labels[id].updateRender(2);
+            this.labels[id].row = 0;
         }
 
-        // If a label overlaps with another, move it up to the top row
+        this.assignRows();
+
         for (var id in this.labels) {
-            if (this.doesItOverlap(this.labels[id])) {
-                // 22 px above wavesurfer canvas
-                this.labels[id].updateRender(22);
-            }
+            this.labels[id].updateRender(2 + (this.rowHeight * (this.labels[id].row % this.maxRows)));
         }
     },
 
-    // Calcuates if a label overlaps with any other label elements
-    doesItOverlap: function(label) {
+    // Assign a label a row to reduce overlap. Wider labels are prioritized to lower rows.
+    assignRows: function() {
         for (var id in this.labels) {
-            var otherLabel = this.labels[id];
-            if (otherLabel === label) {
-                continue;
-            }
-            if ((label.left() <=  otherLabel.right() && label.left() >=  otherLabel.left()) ||
-                (label.right() >=  otherLabel.left() && label.right()  <= otherLabel.right()) ||
-                (label.right() >=  otherLabel.right() && label.left()  <= otherLabel.left())) {
-                return label.region.element.offsetWidth < otherLabel.region.element.offsetWidth;
+            this.labels[id].row = 0;
+        }
+
+        for (var row=0; row < (this.maxRows * 2); row++) {
+            for (var id1 in this.labels) {
+                var label = this.labels[id1];
+
+                for (var id2 in this.labels) {
+                    var otherLabel = this.labels[id2];
+                    if ((otherLabel === label) || (otherLabel.row !== label.row)) {
+                        continue;
+                    }
+
+                    if ((label.left() <=  otherLabel.right() && label.left() >=  otherLabel.left()) ||
+                        (label.right() >=  otherLabel.left() && label.right()  <= otherLabel.right()) ||
+                        (label.right() >=  otherLabel.right() && label.left()  <= otherLabel.left())) {
+                        if (label.region.element.offsetWidth < otherLabel.region.element.offsetWidth) {
+                            label.row += 1;
+                        }
+                    }
+                }
             }
         }
-        return false;
     }
 };
 
@@ -178,6 +192,7 @@ WaveSurfer.Label = {
         region.annotationLabel = this;
         this.region = region;
         this.render();
+        this.row = 0;
     },
 
     // Create and append individual label element

--- a/static/js/src/wavesurfer.labels.js
+++ b/static/js/src/wavesurfer.labels.js
@@ -207,6 +207,18 @@ WaveSurfer.Label = {
         this.text = this.element.appendChild(document.createElement('span'));
         this.text.innerHTML = '?';
 
+        // add delete region to the right
+        this.deleteRegion = labelEl.appendChild(document.createElement('i'));
+        this.deleteRegion.className = 'fa fa-times-circle'
+
+        this.style(this.deleteRegion, {
+            position: 'absolute',
+            marginTop: '3px',
+            right: '0px',
+            marginRight: '5px',
+            cursor: 'pointer'
+        });
+
         // Place the label on the bottom row
         this.updateRender(2);
         this.bindEvents();
@@ -246,6 +258,11 @@ WaveSurfer.Label = {
         // If the user dbl clicks the label, trigger the dblclick event for the assiciated region
         this.element.addEventListener('dblclick', function (e) {
             my.region.wavesurfer.fireEvent('label-dblclick', my.region, e);
+        });
+
+        this.deleteRegion.addEventListener('click', function (e) {
+            e.stopPropagation();
+            my.region.remove();
         });
     }
 };

--- a/static/js/src/wavesurfer.regions.js
+++ b/static/js/src/wavesurfer.regions.js
@@ -264,21 +264,6 @@ WaveSurfer.Region = {
             });
         }
 
-        this.deleteRegion = regionEl.appendChild(document.createElement('i'));
-        this.deleteRegion.className = 'fa fa-times-circle'
-
-        this.style(this.deleteRegion, {
-            position: 'absolute',
-            right: '0px',
-            top: '0px',
-            cursor: 'pointer',
-            fontSize: '20px',
-            borderRadius: '50%',
-            backgroundColor: 'white',
-            height: '17px',
-            width: '17px'
-        });
-
         this.element = this.wrapper.appendChild(regionEl);
         this.handleLeft = handleLeft;
         this.handleRight = handleRight;
@@ -406,11 +391,6 @@ WaveSurfer.Region = {
             e.preventDefault();
             my.fireEvent('click', e);
             my.wavesurfer.fireEvent('region-click', my, e);
-        });
-
-        this.deleteRegion.addEventListener('click', function (e) {
-            e.stopPropagation();
-            my.remove();
         });
 
         this.element.addEventListener('dblclick', function (e) {

--- a/static/js/src/wavesurfer.regions.js
+++ b/static/js/src/wavesurfer.regions.js
@@ -139,7 +139,7 @@ WaveSurfer.Region = {
         this.resize = params.resize === undefined ? true : Boolean(params.resize);
         this.drag = params.drag === undefined ? true : Boolean(params.drag);
         this.loop = Boolean(params.loop);
-        this.color = params.color || 'rgba(252, 238, 137, 0.5)';
+        this.color = params.color || '#7C7C7C';
         this.data = params.data || {};
         this.attributes = params.attributes || {};
         this.annotation = params.annotation || '';

--- a/static/js/src/wavesurfer.regions.js
+++ b/static/js/src/wavesurfer.regions.js
@@ -328,7 +328,6 @@ WaveSurfer.Region = {
             this.style(this.element, {
                 left: ~~(this.start / dur * width) + 'px',
                 width: regionWidth + 'px',
-                backgroundColor: this.color,
                 cursor: this.drag ? 'move' : 'default',
                 zIndex: width - regionWidth
             });


### PR DESCRIPTION
Many users complained about the way annotation labels overlapped when annotating a dense scene. This update removes the annotation boxes from the visualization (except for an outline when creating a new annotation), and allows an arbitrary number of “tracks” to be allocated for the annotation labels (currently set at 6 rather than the previous max of 2).